### PR TITLE
Validate and log errors when given non-numeric values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": ">=5.5.0"
+    "php": ">=5.5.0",
+    "psr/log": "~1.0"
   },
   "authors": [
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,6 @@
 
 namespace Vend\Statsd;
 
-
 /**
  * StatsD Client
  *
@@ -58,7 +57,11 @@ class Client
     {
         if (method_exists($this->factory, $name)) {
             $metric = call_user_func_array([$this->factory, $name], $arguments);
-            $this->add($metric);
+
+            if ($metric) {
+                $this->add($metric);
+            }
+
             return $metric;
         }
 

--- a/src/Datadog/Factory.php
+++ b/src/Datadog/Factory.php
@@ -23,6 +23,10 @@ class Factory extends BaseFactory
      */
     protected function createMetric($key, $value, $type, array $tags = [])
     {
+        if (!$this->validate($key, $value, $type)) {
+            return null;
+        }
+
         return new Metric($key, $value, $type, $tags);
     }
 

--- a/src/Datadog/Factory.php
+++ b/src/Datadog/Factory.php
@@ -59,4 +59,9 @@ class Factory extends BaseFactory
     {
         return $this->createMetric($key, $value, Type::SET, $tags);
     }
+
+    protected function getNumericMetricTypes()
+    {
+        return array_merge(parent::getNumericMetricTypes(), [Type::HISTOGRAM]);
+    }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -78,7 +78,7 @@ class Factory implements FactoryInterface
      */
     protected function validate($key, $value, $type)
     {
-        if (in_array($type, [Type::COUNTER, Type::GAUGE, Type::TIMER], true) && !is_numeric($value) && !preg_match('/^(-|\+)?\d+/', $value)) {
+        if (in_array($type, $this->getNumericMetricTypes(), true) && !is_numeric($value) && !preg_match('/^(-|\+)?\d+/', $value)) {
             $this->logger->error('Could not emit metric: requires an numeric value', [
                 'key'   => $key,
                 'value' => $value,
@@ -89,5 +89,10 @@ class Factory implements FactoryInterface
         }
 
         return true;
+    }
+
+    protected function getNumericMetricTypes()
+    {
+        return [Type::COUNTER, Type::GAUGE, Type::TIMER];
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,16 +2,33 @@
 
 namespace Vend\Statsd;
 
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+
 class Factory implements FactoryInterface
 {
+    use LoggerAwareTrait;
+
+    /**
+     * Factory constructor
+     */
+    public function __construct()
+    {
+        $this->logger = new NullLogger();
+    }
+
     /**
      * @param string $key
      * @param mixed  $value
      * @param string $type
-     * @return Metric
+     * @return Metric|null
      */
     protected function createMetric($key, $value, $type)
     {
+        if (!$this->validate($key, $value, $type)) {
+            return null;
+        }
+
         return new Metric($key, $value, $type);
     }
 
@@ -43,5 +60,34 @@ class Factory implements FactoryInterface
     public function set($key, $value)
     {
         return $this->createMetric($key, $value, Type::SET);
+    }
+
+    /**
+     * Validates the value against the type
+     *
+     * Most metrics require a numeric value. If the value is empty, this can cause receivers to think the format of
+     * the emitted datagrams is invalid. (And, heck, it might be: it's not like etsy/statsd is a formal standard.)
+     *
+     * We treat these errors silently: we log a message and return null from createMetric(), excluding the metric from
+     * being sent via the client.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param string $type
+     * @return bool
+     */
+    protected function validate($key, $value, $type)
+    {
+        if (in_array($type, [Type::COUNTER, Type::GAUGE, Type::TIMER], true) && !is_numeric($value) && !preg_match('/^(-|\+)?\d+/', $value)) {
+            $this->logger->error('Could not emit metric: requires an numeric value', [
+                'key'   => $key,
+                'value' => $value,
+                'type'  => $type,
+            ]);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -2,14 +2,16 @@
 
 namespace Vend\Statsd;
 
-interface FactoryInterface
+use Psr\Log\LoggerAwareInterface;
+
+interface FactoryInterface extends LoggerAwareInterface
 {
     /**
      * Creates an 'counter' metric
      *
      * @param string  $key   The metric(s) to decrement
      * @param integer $delta The delta to add to the each metric
-     * @return Metric
+     * @return Metric|null Null returned if the metric fails validation
      */
     public function counter($key, $delta);
 
@@ -17,7 +19,7 @@ interface FactoryInterface
      * Creates an 'increment' metric
      *
      * @param string $key The metric(s) to increment
-     * @return Metric
+     * @return Metric|null Null returned if the metric fails validation
      */
     public function increment($key);
 
@@ -25,7 +27,7 @@ interface FactoryInterface
      * Creates a 'decrement' metric
      *
      * @param string $key The metric(s) to decrement
-     * @return Metric
+     * @return Metric|null Null returned if the metric fails validation
      */
     public function decrement($key);
 
@@ -34,7 +36,7 @@ interface FactoryInterface
      *
      * @param string $key   The metric(s) to set
      * @param float  $value The value for the stats
-     * @return Metric
+     * @return Metric|null Null returned if the metric fails validation
      */
     public function gauge($key, $value);
 
@@ -43,7 +45,7 @@ interface FactoryInterface
      *
      * @param string $key  The metric(s) to set
      * @param float  $time The elapsed time (ms) to log
-     * @return Metric
+     * @return Metric|null Null returned if the metric fails validation
      */
     public function timer($key, $time);
 
@@ -52,7 +54,7 @@ interface FactoryInterface
      *
      * @param string $key   The metric(s) to set
      * @param float  $value The value for the stats
-     * @return Metric
+     * @return Metric|null Null returned if the metric fails validation
      */
     public function set($key, $value);
 }


### PR DESCRIPTION
So that we don't end up emitting malformed metrics (no value specified) when the caller passes null or false or similar as the value.
